### PR TITLE
Fix REST helpers to accept raw request bodies

### DIFF
--- a/libs/api/src/lib/rest.js
+++ b/libs/api/src/lib/rest.js
@@ -2,6 +2,20 @@ import axios from 'axios';
 
 let opts = { baseUrl: '', getToken: null };
 
+const normalizeOptions = (options) => {
+  if (options === undefined) return {};
+
+  const isPlainObject =
+    options !== null && typeof options === 'object' && !Array.isArray(options);
+
+  if (!isPlainObject) return { body: options };
+
+  const recognizedKeys = ['body', 'baseUrl', 'getToken', 'params'];
+  const hasRecognizedKey = recognizedKeys.some((key) => key in options);
+
+  return hasRecognizedKey ? options : { body: options };
+};
+
 export const configureRest = (options) => {
   opts = { ...opts, ...options };
   axios.defaults.headers.common.accept = 'application/json';
@@ -48,26 +62,34 @@ export const get = (resource, { params, baseUrl, getToken } = {}) =>
     .then((res) => parseResponse(res))
     .catch((err) => handleError(err));
 
-export const post = (resource, { body, baseUrl, getToken } = {}) =>
-  getConfig({ baseUrl, getToken })
+export const post = (resource, options) => {
+  const { body, baseUrl, getToken, params } = normalizeOptions(options);
+  return getConfig({ baseUrl, getToken, params })
     .then((config) => axios.post(resource, body, config))
     .then((res) => parseResponse(res))
     .catch((err) => handleError(err));
+};
 
-export const put = (resource, { body, baseUrl, getToken } = {}) =>
-  getConfig({ baseUrl, getToken })
+export const put = (resource, options) => {
+  const { body, baseUrl, getToken, params } = normalizeOptions(options);
+  return getConfig({ baseUrl, getToken, params })
     .then((config) => axios.put(resource, body, config))
     .then((res) => parseResponse(res))
     .catch((err) => handleError(err));
+};
 
-export const patch = (resource, { body, baseUrl, getToken } = {}) =>
-  getConfig({ baseUrl, getToken })
+export const patch = (resource, options) => {
+  const { body, baseUrl, getToken, params } = normalizeOptions(options);
+  return getConfig({ baseUrl, getToken, params })
     .then((config) => axios.patch(resource, body, config))
     .then((res) => parseResponse(res))
     .catch((err) => handleError(err));
+};
 
-export const del = (resource, { body, baseUrl, getToken } = {}) =>
-  getConfig({ baseUrl, getToken })
+export const del = (resource, options) => {
+  const { body, baseUrl, getToken, params } = normalizeOptions(options);
+  return getConfig({ baseUrl, getToken, params })
     .then((config) => axios.delete(resource, { ...config, data: body }))
     .then((res) => parseResponse(res))
     .catch((err) => handleError(err));
+};

--- a/libs/api/src/lib/rest.spec.js
+++ b/libs/api/src/lib/rest.spec.js
@@ -142,6 +142,36 @@ describe('rest', () => {
       });
     });
 
+    describe('and request passes a raw body', () => {
+      const expectedUrl = random.word();
+      const expectedBody = { payload: random.word() };
+      const expectedData = random.word();
+      let response;
+      let mock;
+
+      beforeAll(async () => {
+        const token = random.uuid();
+        configureRest({ getToken: async () => Promise.resolve(token) });
+        mock = new MockAdapter(axios);
+        mock
+          .onPost(expectedUrl, expectedBody)
+          .reply((config) => {
+            if (config.headers.Authorization !== `Bearer ${token}`) return [401];
+            return [201, expectedData];
+          });
+
+        response = await post(expectedUrl, expectedBody);
+      });
+
+      afterAll(() => {
+        mock.restore();
+      });
+
+      test('should return the proper response', () => {
+        expect(response).toEqual({ ok: true, data: expectedData, status: 201 });
+      });
+    });
+
     describe('and request is failure', () => {
       const expectedUrl = random.word();
       const expectedBody = random.word();
@@ -184,6 +214,35 @@ describe('rest', () => {
             return [200, expectedData];
           });
         response = await put(expectedUrl, { body: expectedBody });
+      });
+
+      afterAll(() => {
+        mock.restore();
+      });
+
+      test('should return the proper response', () => {
+        expect(response).toEqual({ ok: true, data: expectedData, status: 200 });
+      });
+    });
+
+    describe('and request passes a raw body', () => {
+      const expectedUrl = random.word();
+      const expectedBody = { payload: random.word() };
+      const expectedData = random.word();
+      let response;
+      let mock;
+
+      beforeAll(async () => {
+        const token = random.uuid();
+        configureRest({ getToken: async () => Promise.resolve(token) });
+        mock = new MockAdapter(axios);
+        mock
+          .onPut(expectedUrl, expectedBody)
+          .reply((config) => {
+            if (config.headers.Authorization !== `Bearer ${token}`) return [401];
+            return [200, expectedData];
+          });
+        response = await put(expectedUrl, expectedBody);
       });
 
       afterAll(() => {


### PR DESCRIPTION
## Summary
- normalize REST helper options so raw payload objects are sent to axios requests
- add coverage for posting and putting with unwrapped bodies to prevent regressions

## Testing
- n/a (network-restricted environment prevented running `nx test api`)


------
https://chatgpt.com/codex/tasks/task_e_68d34faf60e8832cb9754c41938ffb74