### PR TITLE
Fix memory leak when verifying infractions

### DIFF
--- a/apps/client/shell/src/enforcement/hooks/use-sticky.js
+++ b/apps/client/shell/src/enforcement/hooks/use-sticky.js
@@ -14,23 +14,38 @@ function useSticky() {
 
     // This function handles the scroll performance issue
     const debounce = (func, wait = 20, immediate = true) => {
-      let timeOut;
-      return () => {
-        let context = this,
-          args = arguments;
+      let timeoutId;
+      const debounced = (...args) => {
         const later = () => {
-          timeOut = null;
-          if (!immediate) func.apply(context, args);
+          timeoutId = null;
+          if (!immediate) {
+            func(...args);
+          }
         };
-        const callNow = immediate && !timeOut;
-        clearTimeout(timeOut);
-        timeOut = setTimeout(later, wait);
-        if (callNow) func.apply(context, args);
+        const callNow = immediate && !timeoutId;
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(later, wait);
+        if (callNow) {
+          func(...args);
+        }
       };
+
+      debounced.cancel = () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+      };
+
+      return debounced;
     };
-    window.addEventListener('scroll', debounce(handleScroll));
+
+    const debouncedHandleScroll = debounce(handleScroll);
+    window.addEventListener('scroll', debouncedHandleScroll);
+
     return () => {
-      window.removeEventListener('scroll', () => handleScroll);
+      debouncedHandleScroll.cancel();
+      window.removeEventListener('scroll', debouncedHandleScroll);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- ensure the `useSticky` hook removes its scroll listener by storing the debounced handler and cancelling pending timers during cleanup
- avoid lingering scroll callbacks from updating state after the Infraction component unmounts when navigating the results list

## Testing
- npx nx test client-shell --testFile=apps/client/shell/src/enforcement/pages/verify-correct/results/infraction/infraction.spec.js *(fails: npm 403 fetching nx)*

------
https://chatgpt.com/codex/tasks/task_e_68d439ea8f58832c868249f628e5d00f